### PR TITLE
add workaround for ubuntu network manager ovpn importer

### DIFF
--- a/bin/getclient
+++ b/bin/getclient
@@ -78,10 +78,10 @@ $(openssl x509 -in $EASYRSA_PKI/issued/${cn}.crt)
 <ca>
 $(cat $EASYRSA_PKI/ca.crt)
 </ca>
+key-direction 1
 <tls-auth>
 $(cat $EASYRSA_PKI/ta.key)
 </tls-auth>
-key-direction 1
 
 remote $OVPN_CN $OVPN_PORT $OVPN_PROTO
 


### PR DESCRIPTION
importer fails to set key-direction if it's set after `<tls-auth>`.
Workaround is to set it above.
Ref: https://bugs.launchpad.net/ubuntu/+source/network-manager-openvpn/+bug/1643282