### PR TITLE
Changes to support OpenVPN Connect v3 on MacOS

### DIFF
--- a/bin/getclient
+++ b/bin/getclient
@@ -56,7 +56,6 @@ tls-client
 nobind
 dev tun
 remote-cert-tls server
-comp-lzo
 mute 20
 float
 resolv-retry infinite

--- a/bin/getclient
+++ b/bin/getclient
@@ -59,13 +59,13 @@ remote-cert-tls server
 mute 20
 float
 resolv-retry infinite
-remote-cert-eku 'TLS Web Server Authentication'
+remote-cert-eku "TLS Web Server Authentication"
 remote-cert-ku a0 88
 persist-tun
 auth SHA256
 tls-cipher TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256:TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256
 tls-version-min 1.2
-verify-x509-name 'CN=$(openssl x509 -in $EASYRSA_PKI/issued/${OVPN_CN}.crt -noout -subject | sed 's/subject=CN=//')'
+verify-x509-name "CN=$(openssl x509 -in $EASYRSA_PKI/issued/${OVPN_CN}.crt -noout -subject | sed 's/subject=CN=//')"
 
 <key>
 $(cat $EASYRSA_PKI/private/${cn}.key)

--- a/bin/getclient
+++ b/bin/getclient
@@ -6,10 +6,11 @@
 
 
 usage() {
-    echo "usage: $0 [-M] clientname"
+    echo "usage: $0 [-D] [-M] clientname"
     echo "                 [-M MSSFIX_VALUE]"
     echo
     echo "optional arguments:"
+    echo " -D    Suppress route-delay parameter"
     echo " -M    Set mssfix value"
 }
 
@@ -21,9 +22,14 @@ set -e
 
 source "$OPENVPN/ovpn_env.sh"
 
+OVPN_ROUTE_DELAY=1
+
 # Parse arguments
-while getopts ":M:" opt; do
+while getopts ":DM:" opt; do
     case $opt in
+        D)
+            OVPN_ROUTE_DELAY=0
+            ;;
         M)
             OVPN_MSSFIX=$OPTARG
             ;;
@@ -83,10 +89,12 @@ $(cat $EASYRSA_PKI/ta.key)
 
 remote $OVPN_CN $OVPN_PORT $OVPN_PROTO
 
-#be friendly to windows clients
-route-delay 2
-
 EOF
+
+if [ "$OVPN_ROUTE_DELAY" != "0" ]; then
+    echo "#be friendly to windows clients"
+    echo "route-delay 2"
+fi
 
 if [ "$OVPN_DEFROUTE" != "0" ];then
     echo "redirect-gateway def1"

--- a/bin/getclient
+++ b/bin/getclient
@@ -65,7 +65,7 @@ persist-tun
 auth SHA256
 tls-cipher TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256:TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256:TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256
 tls-version-min 1.2
-verify-x509-name 'CN=$(openssl x509 -in $EASYRSA_PKI/issued/${OVPN_CN}.crt -noout -subject | sed 's/subject=CN = //')'
+verify-x509-name 'CN=$(openssl x509 -in $EASYRSA_PKI/issued/${OVPN_CN}.crt -noout -subject | sed 's/subject=CN=//')'
 
 <key>
 $(cat $EASYRSA_PKI/private/${cn}.key)

--- a/bin/initopenvpn
+++ b/bin/initopenvpn
@@ -171,7 +171,6 @@ key-direction 0
 keepalive 10 60
 persist-key
 persist-tun
-comp-lzo
 mute 20
 float
 remote-cert-eku "TLS Web Client Authentication"


### PR DESCRIPTION
This PR contains few small changes to support OpenVPN Connect v3 client on MacOS. It was also tested on Tunnelblick 4.0.1.
The commit messages describes the changes, which are self-contained. I.e., they are independent of each other, and can be individually reverted if needed.
